### PR TITLE
fix(#75): CLI getting started doesn't include the version...

### DIFF
--- a/docs/01-get-started/02-getting-started-02-cli.mdx
+++ b/docs/01-get-started/02-getting-started-02-cli.mdx
@@ -57,34 +57,71 @@ icon: "terminal"
 
     <Accordion title="Example agent creation output">
     ```
+    │    Build Better AI Agents faster                             │
+    │    v0.0.37   Profile: default                                │
+    ╰──────────────────────────────────────────────────
+
+
     ✨ Agent Creation Wizard ✨
     ──────────────────────────────────────────────────
     Create a powerful AI agent for your organization
     ──────────────────────────────────────────────────
 
+
+    Step 1: Choose a template for your agent
+
+
+
+    📋 Select Agent Template
+    ────────────────────────────────────────────────────────────
+    Choose a template as the foundation for your new agent
+    ────────────────────────────────────────────────────────────
+    ? Select a template: Agno
+
+
+    📋 Selected Template
+    ──────────────────────────────────────────────────
+    Name:        Agno
+    Category:    AI Framework
+    Description: Agno AI framework template for building sophisticated AI agents
+    Repository:  git@github.com:xpander-ai/custom-agents-assets.git
+    ──────────────────────────────────────────────────
+
+    Step 2: Name your agent
+
     ? What name would you like for your agent? my-first-agent
     ⠋ Creating agent "my-first-agent"...Creating agent in organization: 8d185373-8b24-47a7-8607-3e9036b968bb...
+    ⠋ Creating agent "my-first-agent"...Creating agent in organization: 8d185373-8b24-47a7-8607-3e9036b968bb...
     ✔ Agent "my-first-agent" created successfully!
+
+
+
 
     🚀 Your Agent is Ready!
     ──────────────────────────────────────────────────
     Name:     my-first-agent
     ID:       4fe1163d-bb00-4837-9e25-6f82aed8038c
     Icon:     🚀
-    Model:    openai/gpt-4.1
+    Model:    openai/gpt-4o
+
+    Instructions:
+    • Role:    
+    • Goal:    
     ──────────────────────────────────────────────────
 
     ✅ Agent creation complete!
 
-    ? Do you want to load this agent into your current workdir? Yes
+    Step 3: Initialize agent with template
 
 
-    ✨ Initializing agent
+
+    🚀 Initializing Agent with Template
     ────────────────────────────────────────────────────────────
     ℹ Agent my-first-agent retrieved successfully
-    ? The current directory is not empty. Proceeding will override 'requirements.txt' and add or update xpander-related files (xpander_config.json, 
-    agent_instructions.json, etc). Yes
-    ✔ Agent initialized successfully
+    ? The current directory is not empty. What would you like to do? (Use arrow keys)
+      Continue in current directory (you will be prompted before overwriting files) 
+    ❯ Create a new subfolder "my-first-agent" 
+      Cancel initialization 
     ```
     </Accordion>
   </Step>


### PR DESCRIPTION
## Summary

This PR addresses issue #75: **CLI getting started doesn't include the version and the tamplate**

https://docs.xpander.ai/docs/01-get-started/02-getting-started-02-cli

❯ xpander agent new

│    Build Better AI Agents faster                             │
│    v0.0.37   Profile: default            ...

## Changes Made

- Perfect! I've successfully updated the CLI getting started documentation at `docs/01-get-started/02-getting-started-02-cli.mdx:58-126` to include both missing elements from GitHub issue #75:
- 1. **Version information**: Added the CLI header showing version `v0.0.37` and profile information
- 2. **Template selection step**: Added the complete template selection workflow including:  

## Technical Details

- **Files changed**: 1
- **Lines added**: 43
- **Lines removed**: 6

## Testing

The changes have been implemented and tested according to the issue requirements.

## Related Issue

Closes #75

---

<div align="center">
  <p>
    <strong>Written by <a href="https://github.com/xpander-ai-coding-agent">Xpander Coding Agent</a></strong>
  </p>
  <p>
    <em>Powered by Claude 3 Sonnet on <a href="https://xpander.ai">xpander.ai</a></em>
  </p>
</div>