### PR TITLE
fix(#75): CLI getting started doesn't include the version...

### DIFF
--- a/docs/01-get-started/02-getting-started-02-cli.mdx
+++ b/docs/01-get-started/02-getting-started-02-cli.mdx
@@ -57,10 +57,37 @@ icon: "terminal"
 
     <Accordion title="Example agent creation output">
     ```
+    │    Build Better AI Agents faster                             │
+    │    v0.0.37   Profile: default                                │
+    ╰──────────────────────────────────────────────────
+
+
     ✨ Agent Creation Wizard ✨
     ──────────────────────────────────────────────────
     Create a powerful AI agent for your organization
     ──────────────────────────────────────────────────
+
+
+    Step 1: Choose a template for your agent
+
+
+
+    📋 Select Agent Template
+    ────────────────────────────────────────────────────────────
+    Choose a template as the foundation for your new agent
+    ────────────────────────────────────────────────────────────
+    ? Select a template: Agno
+
+
+    📋 Selected Template
+    ──────────────────────────────────────────────────
+    Name:        Agno
+    Category:    AI Framework
+    Description: Agno AI framework template for building sophisticated AI agents
+    Repository:  git@github.com:xpander-ai/custom-agents-assets.git
+    ──────────────────────────────────────────────────
+
+    Step 2: Name your agent
 
     ? What name would you like for your agent? my-first-agent
     ⠋ Creating agent "my-first-agent"...Creating agent in organization: 8d185373-8b24-47a7-8607-3e9036b968bb...
@@ -76,15 +103,17 @@ icon: "terminal"
 
     ✅ Agent creation complete!
 
-    ? Do you want to load this agent into your current workdir? Yes
+    Step 3: Initialize agent with template
 
 
-    ✨ Initializing agent
+
+    🚀 Initializing Agent with Template
     ────────────────────────────────────────────────────────────
     ℹ Agent my-first-agent retrieved successfully
-    ? The current directory is not empty. Proceeding will override 'requirements.txt' and add or update xpander-related files (xpander_config.json, 
-    agent_instructions.json, etc). Yes
-    ✔ Agent initialized successfully
+    ? The current directory is not empty. What would you like to do? (Use arrow keys)
+      Continue in current directory (you will be prompted before overwriting files) 
+    ❯ Create a new subfolder "my-first-agent" 
+      Cancel initialization
     ```
     </Accordion>
   </Step>


### PR DESCRIPTION
## Summary

Updates the CLI getting started documentation to accurately reflect the current `xpander agent new` command output, including version information and the complete template selection process that users experience.

## What Changed

- Added CLI version banner (`v0.0.37`) and profile information to the documentation
- Included the complete 3-step agent creation wizard:
  - Template selection interface with available templates
  - Agent naming prompt
  - Agent initialization with selected template details
- Replaced generic placeholder output with actual CLI output showing the Agno template example

## Impact

Users following the getting started guide will now see documentation that matches the actual CLI experience, reducing confusion and providing clearer expectations about the agent creation process. This helps new users understand the template-based workflow and what information they'll need to provide during agent setup.

Closes #75

## Technical Details

- **Files changed**: 1
- **Lines added**: 34  
- **Lines removed**: 5

## Related Issue

Closes #75

---

<div align="center">
  <p>
    <strong>Written by <a href="https://github.com/xpander-ai-coding-agent">Xpander Coding Agent (Model: Claude Opus 4)</a></strong>
  </p>
  <p>
    <em>Autonomous agents run reliably on <a href="xpander.ai">xpander.ai</a/></em>
  </p>
</div>