### PR TITLE
fix(#75): CLI getting started doesn't include the version...

### DIFF
--- a/docs/01-get-started/02-getting-started-02-cli.mdx
+++ b/docs/01-get-started/02-getting-started-02-cli.mdx
@@ -57,10 +57,37 @@ icon: "terminal"
 
     <Accordion title="Example agent creation output">
     ```
+    │    Build Better AI Agents faster                             │
+    │    v0.0.37   Profile: default                                │
+    ╰──────────────────────────────────────────────────
+
+
     ✨ Agent Creation Wizard ✨
     ──────────────────────────────────────────────────
     Create a powerful AI agent for your organization
     ──────────────────────────────────────────────────
+
+
+    Step 1: Choose a template for your agent
+
+
+
+    📋 Select Agent Template
+    ────────────────────────────────────────────────────────────
+    Choose a template as the foundation for your new agent
+    ────────────────────────────────────────────────────────────
+    ? Select a template: Agno
+
+
+    📋 Selected Template
+    ──────────────────────────────────────────────────
+    Name:        Agno
+    Category:    AI Framework
+    Description: Agno AI framework template for building sophisticated AI agents
+    Repository:  git@github.com:xpander-ai/custom-agents-assets.git
+    ──────────────────────────────────────────────────
+
+    Step 2: Name your agent
 
     ? What name would you like for your agent? my-first-agent
     ⠋ Creating agent "my-first-agent"...Creating agent in organization: 8d185373-8b24-47a7-8607-3e9036b968bb...
@@ -76,14 +103,14 @@ icon: "terminal"
 
     ✅ Agent creation complete!
 
-    ? Do you want to load this agent into your current workdir? Yes
+    Step 3: Initialize agent with template
 
 
-    ✨ Initializing agent
+
+    🚀 Initializing Agent with Template
     ────────────────────────────────────────────────────────────
     ℹ Agent my-first-agent retrieved successfully
-    ? The current directory is not empty. Proceeding will override 'requirements.txt' and add or update xpander-related files (xpander_config.json, 
-    agent_instructions.json, etc). Yes
+    ? The current directory is not empty. What would you like to do? Create a new subfolder "my-first-agent"
     ✔ Agent initialized successfully
     ```
     </Accordion>


### PR DESCRIPTION
## Summary

Updates the CLI getting started documentation to include the complete agent creation wizard output, including the CLI version header and template selection flow. This ensures new users see exactly what to expect when running `xpander agent new`.

## What Changed

- Added the CLI header showing version (v0.0.37) and profile information
- Included the complete template selection flow with step-by-step wizard navigation
- Added template details display showing name, category, description, and repository
- Expanded the example output from ~20 lines to ~56 lines for complete clarity

## Impact

New users following the documentation will now have a comprehensive understanding of the agent creation process before running the command. The complete wizard flow eliminates confusion about template selection and provides clear expectations about each step of the agent creation process.

Closes #75

## Technical Details

- **Files changed**: 1
- **Lines added**: 31  
- **Lines removed**: 4

## Related Issue

Closes #75

---

<div align="center">
  <a href="https://xpander.ai">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20White%20text.png?raw=true">
      <img src="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20Black%20Text.png?raw=true" height="24" alt="xpander.ai">
    </picture>
  </a>
  <br>
  <sub><b>Xpander Coding Agent</b> • Model: Claude Opus 4 • <a href="https://github.com/xpander-ai-coding-agent">GitHub</a></sub>
  <br>
  <sub>Autonomous agents run reliably on <a href="https://xpander.ai">xpander.ai</a></sub>
</div>