### PR TITLE
fix(#75): CLI getting started doesn't include the version...

### DIFF
--- a/docs/01-get-started/02-getting-started-02-cli.mdx
+++ b/docs/01-get-started/02-getting-started-02-cli.mdx
@@ -57,10 +57,37 @@ icon: "terminal"
 
     <Accordion title="Example agent creation output">
     ```
+    │    Build Better AI Agents faster                             │
+    │    v0.0.37   Profile: default                                │
+    ╰──────────────────────────────────────────────────
+
+
     ✨ Agent Creation Wizard ✨
     ──────────────────────────────────────────────────
     Create a powerful AI agent for your organization
     ──────────────────────────────────────────────────
+
+
+    Step 1: Choose a template for your agent
+
+
+
+    📋 Select Agent Template
+    ────────────────────────────────────────────────────────────
+    Choose a template as the foundation for your new agent
+    ────────────────────────────────────────────────────────────
+    ? Select a template: Agno
+
+
+    📋 Selected Template
+    ──────────────────────────────────────────────────
+    Name:        Agno
+    Category:    AI Framework
+    Description: Agno AI framework template for building sophisticated AI agents
+    Repository:  git@github.com:xpander-ai/custom-agents-assets.git
+    ──────────────────────────────────────────────────
+
+    Step 2: Name your agent
 
     ? What name would you like for your agent? my-first-agent
     ⠋ Creating agent "my-first-agent"...Creating agent in organization: 8d185373-8b24-47a7-8607-3e9036b968bb...
@@ -71,20 +98,26 @@ icon: "terminal"
     Name:     my-first-agent
     ID:       4fe1163d-bb00-4837-9e25-6f82aed8038c
     Icon:     🚀
-    Model:    openai/gpt-4.1
+    Model:    openai/gpt-4o
+
+    Instructions:
+    • Role:    
+    • Goal:    
     ──────────────────────────────────────────────────
 
     ✅ Agent creation complete!
 
-    ? Do you want to load this agent into your current workdir? Yes
+    Step 3: Initialize agent with template
 
 
-    ✨ Initializing agent
+
+    🚀 Initializing Agent with Template
     ────────────────────────────────────────────────────────────
     ℹ Agent my-first-agent retrieved successfully
-    ? The current directory is not empty. Proceeding will override 'requirements.txt' and add or update xpander-related files (xpander_config.json, 
-    agent_instructions.json, etc). Yes
-    ✔ Agent initialized successfully
+    ? The current directory is not empty. What would you like to do? 
+      Continue in current directory (you will be prompted before overwriting files) 
+    ❯ Create a new subfolder "my-first-agent" 
+      Cancel initialization 
     ```
     </Accordion>
   </Step>
@@ -95,7 +128,7 @@ icon: "terminal"
     ```txt .env file
     XPANDER_API_KEY=your_xpander_api_key  # From the xpander login output
     OPENAI_API_KEY=your_openai_api_key
-    OPENAI_MODEL_ID=gpt-4.1
+    OPENAI_MODEL_ID=gpt-4o
     ```
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary

Updates the CLI getting started documentation to accurately reflect the current CLI user experience, including the version banner display and the complete template selection workflow that users encounter when creating a new agent.

## What Changed

- Added CLI version banner (`v0.0.37`) that displays at the top of the xpander agent command output
- Included the complete template selection wizard with:
  - Step-by-step agent creation flow
  - Template selection interface showing available templates
  - Selected template details (Agno template with category and description)
  - Agent naming and initialization prompts
- Updated the AI model reference from `gpt-4.1` to `gpt-4o` to match current defaults
- Enhanced the initialization flow to show directory selection options

## Impact

Users following the getting started guide will now see documentation that matches their actual CLI experience, reducing confusion and improving onboarding. The complete template selection flow helps users understand the agent creation process before running the command.

Closes #75

## Technical Details

- **Files changed**: 1
- **Lines added**: 40  
- **Lines removed**: 7

## Related Issue

Closes #75

---

<div align="center">
  <a href="https://xpander.ai">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20White%20text.png?raw=true">
      <img src="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20Black%20Text.png?raw=true" height="24" alt="xpander.ai">
    </picture>
  </a>
  <br>
  <sub><b>Xpander Coding Agent</b> • Model: Claude Opus 4 • <a href="https://github.com/xpander-ai-coding-agent">GitHub</a></sub>
  <br>
  <sub>Autonomous agents run reliably on <a href="https://xpander.ai">xpander.ai</a></sub>
</div>