### PR TITLE
Fix typos

### DIFF
--- a/tutorials/05-travel-expense-assistant.mdx
+++ b/tutorials/05-travel-expense-assistant.mdx
@@ -36,7 +36,7 @@ The Xpander ecosystem contains several packages that streamline agent developmen
 ## 🎯 What We're Building: Travel & Expense Assistant
 
 <Frame>
-  <video autoPlay muted loop playsInline className="w-full aspect-video" src="https://assets.xpanderai.io/Travel_Expense_Assistant_Demo.mp4" />
+  <video autoPlay loop playsInline className="w-full aspect-video" src="https://assets.xpanderai.io/Travel_Expense_Assistant_Video_Demo.mp4" />
 </Frame>
 
 Below is the high-level user journey for our assistant (powered by Agno agents and orchestrated by Xpander):

--- a/tutorials/06-github-pr-review-agent.mdx
+++ b/tutorials/06-github-pr-review-agent.mdx
@@ -17,7 +17,7 @@ Large pull requests slow teams down and hide critical issues. Let's combine **Xp
 ## 🗺️ What We're Building
 
 <Frame>
-  <video autoPlay muted loop playsInline className="w-full aspect-video" src="https://assets.xpanderai.io/GitHub_PR_Review_Agent_Demo.mp4" />
+  <video autoPlay loop playsInline className="w-full aspect-video" src="https://assets.xpanderai.io/GitHub_PR_Review_Agent_Demo.mp4" />
 </Frame>
 
 Our agent will:


### PR DESCRIPTION
This pull request includes minor updates to video links in two tutorial files to improve clarity and consistency.

### Updates to video links:

* [`tutorials/05-travel-expense-assistant.mdx`](diffhunk://#diff-404a1ee4119d1ab2a4f4c4451fbb4e6cbb8e76a15f3c63cbbd21b93ca0cebe29L39-R39): Updated the video source URL to `Travel_Expense_Assistant_Video_Demo.mp4` for better naming clarity.
* [`tutorials/06-github-pr-review-agent.mdx`](diffhunk://#diff-5a35d4b02c0bca0487f8dff0f8a7e22aa2380989035e4fc2be7de5bc41c01f6aL20-R20): Removed the `muted` attribute from the video tag to allow audio playback and updated the video source URL for consistency.